### PR TITLE
ds-buffer: impl get_caps for popn music support

### DIFF
--- a/src/ds-buffer.c
+++ b/src/ds-buffer.c
@@ -356,9 +356,25 @@ static __stdcall HRESULT ds_buffer_get_caps(
         IDirectSoundBuffer *com,
         DSBCAPS *out)
 {
+    struct ds_buffer *self;
+
     trace("%s(%p) [stub]", __func__, out);
 
-    return E_NOTIMPL;
+    if (out == NULL) {
+        return E_POINTER;
+    }
+
+    if (out->dwSize != sizeof(*out)) {
+        trace("%s: unexpected out param size: %i", __func__, out->dwSize);
+        return E_INVALIDARG;
+    }
+
+    self = ds_buffer_downcast(com);
+    out->dwBufferBytes = self->conv_nbytes;
+    out->dwUnlockTransferRate = 100000000;
+    out->dwPlayCpuOverhead = 0;
+
+    return 0;
 }
 
 static __stdcall HRESULT ds_buffer_get_current_position(


### PR DESCRIPTION
It seems pop'n music calls this function to do.... something? Would be nice if we could get more insight about what specifically its using. However, it does work with these values.

For now, main thing to think about is if the dummy values I've provided here are the best possible ones. Notably, I don't advertise any capabilities in `dwFlags` at all, and `dwUnlockTransferRate` and `dwPlayCpuOverhead` are set to extremes for an optimistic report.

Relevant docs:
https://learn.microsoft.com/en-us/previous-versions/windows/desktop/mt708924(v=vs.85)
https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ee416818(v=vs.85)